### PR TITLE
Cleanup Guess Displays

### DIFF
--- a/src/components/guesses/GuessList.tsx
+++ b/src/components/guesses/GuessList.tsx
@@ -1,30 +1,44 @@
+import { GuessWithShow } from '@/models/guess.model';
 import { useThemeContext } from '@/store/theme.store';
 import { AvatarConfig } from '@/types/main';
-import { OrganizedGuesses } from '@/utils/guess.util';
+import { OrganizedGuessesWithShow } from '@/utils/guess.util';
 import { Show } from '@prisma/client';
 import { useSession } from 'next-auth/react';
 import Link from 'next/link';
-import React, { useState } from 'react';
+import React from 'react';
 import AvatarIcon from '../shared/Avatar/AvatarIcon';
 import ToggleDropdown from '../shared/ToggleDropdown';
 
-interface GuessListProps {
-  organizedGuesses: OrganizedGuesses;
-  nightShow: Show | null;
+interface GuessListItemProps {
+  guess: GuessWithShow;
+  showRunNight?: boolean;
 }
 
-//const resolveGuesses = (organizedGuesses: Record<UserID, {"complete": Guess[], "incomplete": Guess[]}>, users: Record<UserID, User>): {user: User, guesses: {"complete": Guess[], "incomplete": Guess[]}}[];
+const GuessListItem: React.FC<GuessListItemProps> = ({ guess, showRunNight }) => (
+  <div className={`flex w-full ${guess.completed ? 'opacity-50' : ''}`}>
+    <a href={`https://www.phish.net/song/${guess.songId}`} target="_blank">
+      <p className={`m-0 ${guess.completed ? 'line-through' : ''}`}>
+        {guess.songName}
+        {guess.encore ? ' (e)' : ''}
+      </p>
+    </a>
+    {showRunNight ? <p className="ml-auto">N{guess.show.runNight}</p> : null}
+  </div>
+);
+
+interface GuessListProps {
+  organizedGuesses: OrganizedGuessesWithShow;
+  nightShow: Show | null;
+}
 
 const GuessList: React.FC<GuessListProps> = ({ organizedGuesses, nightShow }) => {
   //const resolvesGuesses: {user: User, guesses: {"complete": Guess[], "incomplete": Guess[]}}[] = zip(users, organizedGuesses);
   const { color } = useThemeContext();
   const { data: session } = useSession();
   const currentUserId = session?.user?.id;
-  const [openUserIds, setOpenUserIds] = useState<number[]>([]);
-  const toggleUser = (userId: number) =>
-    setOpenUserIds((ids) => (ids.includes(userId) ? ids.filter((id) => id !== userId) : [...ids, userId]));
+  const isRunTotal = nightShow === null;
 
-  if (nightShow && Object.keys(organizedGuesses).length === 0) {
+  if (!isRunTotal && Object.keys(organizedGuesses).length === 0) {
     return (
       <div className="flex flex-col items-center">
         <p className="my-4">There are no guesses for this show yet!</p>
@@ -65,27 +79,13 @@ const GuessList: React.FC<GuessListProps> = ({ organizedGuesses, nightShow }) =>
             <div className="px-5 mt-3" id="user-guesses">
               <div className="flex flex-col space-y-2">
                 {guesses.incomplete.map((guess) => (
-                  <div key={guess.id}>
-                    <a href={`https://www.phish.net/song/${guess.songId}`} target="_blank">
-                      <p className="m-0">
-                        {guess.songName}
-                        {guess.encore ? ' (e)' : ''}
-                      </p>
-                    </a>
-                  </div>
+                  <GuessListItem guess={guess} key={`guess-${guess.id}`} showRunNight={isRunTotal} />
                 ))}
               </div>
               {guesses.complete.length > 0 && <div className="divider dark:bg-white dark:bg-opacity-25" />}
               <div className="flex flex-col space-y-2">
                 {guesses.complete.map((guess) => (
-                  <div key={guess.id}>
-                    <a href={`https://www.phish.net/song/${guess.songId}`} target="_blank">
-                      <p className="line-through opacity-50 m-0">
-                        {guess.songName}
-                        {guess.encore ? ' (e)' : ''}
-                      </p>
-                    </a>
-                  </div>
+                  <GuessListItem guess={guess} key={`guess-${guess.id}`} showRunNight={isRunTotal} />
                 ))}
               </div>
             </div>

--- a/src/components/guesses/run/GuessRunContainer.tsx
+++ b/src/components/guesses/run/GuessRunContainer.tsx
@@ -6,7 +6,7 @@ import TitleBar from '@/components/shared/TitleBar';
 import { RunWithVenue } from '@/models/run.model';
 import { ShowWithVenue } from '@/models/show.model';
 import { useThemeContext } from '@/store/theme.store';
-import { OrganizedGuesses, organizedGuessesForNight } from '@/utils/guess.util';
+import { organizedGuessesForNight, OrganizedGuessesWithShow } from '@/utils/guess.util';
 import { Show } from '@prisma/client';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -15,7 +15,7 @@ import React from 'react';
 export interface GuessRunContainerProps {
   run: RunWithVenue;
   shows: ShowWithVenue[];
-  guesses: OrganizedGuesses;
+  guesses: OrganizedGuessesWithShow;
 }
 
 const GuessRunContainer: React.FC<GuessRunContainerProps> = ({ run, shows, guesses }) => {

--- a/src/components/scores/Leaderboard.tsx
+++ b/src/components/scores/Leaderboard.tsx
@@ -1,19 +1,39 @@
 import AvatarIcon from '@/components/shared/Avatar/AvatarIcon';
+import { GuessWithShow } from '@/models/guess.model';
 import { defaultAvatar } from '@/models/user.model';
 import { AvatarConfig } from '@/types/main';
-import { Guess, User } from '@prisma/client';
+import { RankedUserScores } from '@/utils/guess.util';
+import { Show } from '@prisma/client';
 import Link from 'next/link';
-import React, { useState } from 'react';
+import React from 'react';
 import ToggleDropdown from '../shared/ToggleDropdown';
 
-interface LeaderboardInfoProps {
-  rankedUserScores: { user: User; points: number; guesses: Guess[] }[];
+interface LeaderboardGuessItemProps {
+  guess: GuessWithShow;
+  showRunNight?: boolean;
 }
 
-const LeaderboardInfo: React.FC<LeaderboardInfoProps> = ({ rankedUserScores }) => {
-  const [openUserIds, setOpenUserIds] = useState<number[]>([]);
-  const toggleUser = (userId: number) =>
-    setOpenUserIds((ids) => (ids.includes(userId) ? ids.filter((id) => id !== userId) : [...ids, userId]));
+const LeaderboardGuessItem: React.FC<LeaderboardGuessItemProps> = ({ guess, showRunNight }) => (
+  <div className="flex justify-between ">
+    <a href={`https://www.phish.net/song/${guess.songId}`} target="_blank">
+      <p className="m-0">
+        {guess.songName} {guess.encore && guess.points > 1 ? ' (e)' : ''}
+      </p>
+    </a>
+    <div className="flex items-center space-x-1">
+      {showRunNight ? <p className="m-0 opacity-50">N{guess.show.runNight} •</p> : null}
+      <p className="m-0">{`${guess.points} pts`}</p>
+    </div>
+  </div>
+);
+
+interface LeaderboardInfoProps {
+  rankedUserScores: RankedUserScores;
+  nightShow: Show | null;
+}
+
+const LeaderboardInfo: React.FC<LeaderboardInfoProps> = ({ rankedUserScores, nightShow }) => {
+  const isRunTotal = nightShow === null;
 
   if (rankedUserScores.length === 0) {
     return <p className="text-center mt-4">There are no scores for this show yet!</p>;
@@ -47,15 +67,8 @@ const LeaderboardInfo: React.FC<LeaderboardInfoProps> = ({ rankedUserScores }) =
             }
           >
             <div className="px-5 mr-0.5 space-y-2 mt-3">
-              {guesses.map((score) => (
-                <div key={score.id} className="flex justify-between ">
-                  <p className="m-0">
-                    {score.songName} {score.encore && score.points > 1 ? ' (e)' : ''}
-                  </p>
-                  <div className="flex items-center space-x-1">
-                    <p className="m-0">{`${score.points} pts`}</p>
-                  </div>
-                </div>
+              {guesses.map((guess) => (
+                <LeaderboardGuessItem guess={guess} key={`score-${guess.id}`} showRunNight={isRunTotal} />
               ))}
             </div>
           </ToggleDropdown>

--- a/src/components/scores/run/RunScoreContainer.tsx
+++ b/src/components/scores/run/RunScoreContainer.tsx
@@ -65,7 +65,7 @@ const RunScoreContainer: React.FC<RunScoreContainerProps> = ({ run, shows, ranke
           select={(nightNumber) => chooseNight(nightNumber)}
           containerClass="mt-4"
         />
-        <LeaderboardInfo rankedUserScores={organizedScores} />
+        <LeaderboardInfo rankedUserScores={organizedScores} nightShow={nightShow || null} />
       </div>
     </div>
   );

--- a/src/components/users/profile/EditProfileModal.tsx
+++ b/src/components/users/profile/EditProfileModal.tsx
@@ -22,10 +22,10 @@ import React, { useState } from 'react';
 import toast from 'react-hot-toast';
 import Modal from 'react-modal';
 import { useDispatch, useSelector } from 'react-redux';
-import { AvatarIconSized } from '../shared/Avatar/AvatarIcon';
-import InputField from '../shared/InputField';
-import LoadingSpinner from '../shared/LoadingSpinner';
-import AvatarEditorModal from './AvatarEditor/AvatarEditor';
+import { AvatarIconSized } from '../../shared/Avatar/AvatarIcon';
+import InputField from '../../shared/InputField';
+import LoadingSpinner from '../../shared/LoadingSpinner';
+import AvatarEditorModal from '../AvatarEditor/AvatarEditor';
 
 Modal.setAppElement('#__next');
 

--- a/src/components/users/profile/ProfileHeader.tsx
+++ b/src/components/users/profile/ProfileHeader.tsx
@@ -3,7 +3,7 @@ import { AvatarConfig } from '@/types/main';
 import { User } from '@prisma/client';
 import { useSession } from 'next-auth/react';
 import React from 'react';
-import { AvatarIconSized } from '../shared/Avatar/AvatarIcon';
+import { AvatarIconSized } from '../../shared/Avatar/AvatarIcon';
 import ProfileControls from './ProfileControls';
 
 interface ProfileHeaderProps {

--- a/src/components/users/profile/RunRecord.tsx
+++ b/src/components/users/profile/RunRecord.tsx
@@ -4,7 +4,7 @@ import { OrganizedRunItem } from '@/utils/guess.util';
 import { toTitleCase } from '@/utils/utils';
 import moment from 'moment';
 import React, { useState } from 'react';
-import ToggleDropdown from '../shared/ToggleDropdown';
+import ToggleDropdown from '../../shared/ToggleDropdown';
 
 interface RunRecordProps {
   runRecord: OrganizedRunItem[];

--- a/src/models/guess.model.ts
+++ b/src/models/guess.model.ts
@@ -1,0 +1,9 @@
+import { Guess, Prisma, Show } from '@prisma/client';
+
+export type GuessQuery = Prisma.GuessWhereInput;
+
+export type GuessOrderByQuery = Prisma.Enumerable<Prisma.GuessOrderByWithRelationInput>;
+
+export type GuessWithShow = Guess & {
+  show: Show;
+};

--- a/src/pages/scores/run/[runId].tsx
+++ b/src/pages/scores/run/[runId].tsx
@@ -1,13 +1,13 @@
 import RunScoreContainer, { RunScoreContainerProps } from '@/components/scores/run/RunScoreContainer';
 import ErrorMessage from '@/components/shared/ErrorMessage';
+import { GuessWithShow } from '@/models/guess.model';
 import { getGuessesForRun } from '@/services/guess.service';
 import { getRunWithVenue } from '@/services/run.service';
 import { getShowsForRunWithVenue } from '@/services/show.service';
 import { getUsersByIds } from '@/services/user.service';
 import { ResponseStatus } from '@/types/main';
-import { rankScoresByUser } from '@/utils/guess.util';
+import { buildGuessesWithShows, rankScoresByUser } from '@/utils/guess.util';
 import { organizeArrayByField, parseObj } from '@/utils/utils';
-import { Guess } from '@prisma/client';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import React from 'react';
@@ -44,7 +44,8 @@ export const getServerSideProps: GetServerSideProps<RunScorePageProps> = async (
     };
   }
   guesses = JSON.parse(JSON.stringify(guesses)) as typeof guesses;
-  const guessesByUser = organizeArrayByField<Guess>(guesses, 'userId');
+  const guessesWithShow = buildGuessesWithShows(guesses, shows);
+  const guessesByUser = organizeArrayByField<GuessWithShow>(guessesWithShow, 'userId');
   const userIds = Object.keys(guessesByUser).map((user) => parseInt(user));
   let users = await getUsersByIds(userIds);
   if (users === ResponseStatus.NotFound) {


### PR DESCRIPTION
Cleanup guess/leaderboard pages. Closes #20.
- show night number for total guesses
- hide users on nights they had no guesses
- create reusable components for guess items